### PR TITLE
gravatar fix with version update

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,6 +1,6 @@
 markdown==2.3.1
 Django==2.1.2
-django-gravatar2==1.1.4
+django-gravatar2==1.4.0
 django-nose==1.4.6
 gunicorn==19.9.0
 https://github.com/zsiciarz/django-markitup/archive/django2.0.zip#egg=django-markitup


### PR DESCRIPTION
older version gravatar returns html with escape characters so it does not work as gravatar, with thoose update that bug fixed

ref:
https://github.com/twaddington/django-gravatar/issues/21